### PR TITLE
Add Google Domains component

### DIFF
--- a/homeassistant/components/google_domains.py
+++ b/homeassistant/components/google_domains.py
@@ -1,0 +1,76 @@
+"""Integrate with Google Domains."""
+import asyncio
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_DOMAIN, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.loader import bind_hass
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+DOMAIN = 'google_domains'
+UPDATE_URL = 'https://{}:{}@domains.google.com/nic/update'
+INTERVAL = timedelta(minutes=5)
+_LOGGER = logging.getLogger(__name__)
+SERVICE_UPDATE_DNS = 'update_dns'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DOMAIN): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Initialize the Google Domains component."""
+    domain = config[DOMAIN][CONF_DOMAIN]
+    user = config[DOMAIN][CONF_USERNAME]
+    password = config[DOMAIN][CONF_PASSWORD]
+    session = async_get_clientsession(hass)
+
+    result = yield from _update_google_domains(session, domain, user, password)
+
+    if not result:
+        return False
+
+    @asyncio.coroutine
+    def update_domain_interval(now):
+        """Update the Google Domains entry."""
+        yield from _update_google_domains(session, domain, user, password)
+
+    @asyncio.coroutine
+    def update_domain_service(call):
+        """Update the Google Domains entry."""
+        yield from _update_google_domains(session, domain, user, password)
+
+    async_track_time_interval(hass, update_domain_interval, INTERVAL)
+    hass.services.async_register(DOMAIN, SERVICE_UPDATE_DNS, update_domain_service)
+
+    return result
+
+
+@asyncio.coroutine
+def _update_google_domains(session, domain, user, password):
+    """Update Google Domains."""
+    url = UPDATE_URL.format(user, password)
+    
+    params = {
+        'hostname': domain
+    }
+
+    resp = yield from session.get(url, params=params)
+    body = yield from resp.text()
+    
+    _LOGGER.debug(body)
+
+    if not body.startswith('good') and not body.startswith('nochg'):
+        _LOGGER.warning('Updating Google Domains domain %s failed: %s', domain)
+        return False
+
+    return True


### PR DESCRIPTION
## Description:
Adds support for updating Google Domains dynamic DNS records.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
google_domains:
  domain: subdomain.domain.com
  username: abc123
  password: xyz345
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
